### PR TITLE
Write correct unlockheight for inputs

### DIFF
--- a/transactions/bidtx.go
+++ b/transactions/bidtx.go
@@ -73,7 +73,7 @@ func (b *Bid) Equals(t Transaction) bool {
 	return true
 }
 
-func (b *Bid) UnlockHeight() uint64 {
+func (b *Bid) LockTime() uint64 {
 	return b.Lock
 }
 

--- a/transactions/coinbasetx.go
+++ b/transactions/coinbasetx.go
@@ -120,7 +120,7 @@ func (s *Coinbase) Equals(t Transaction) bool {
 	return true
 }
 
-func (s *Coinbase) UnlockHeight() uint64 {
+func (s *Coinbase) LockTime() uint64 {
 	return 0
 }
 

--- a/transactions/interfaces.go
+++ b/transactions/interfaces.go
@@ -19,5 +19,5 @@ type Transaction interface {
 	merkletree.Payload
 	Equals(Transaction) bool
 	StandardTx() *Standard
-	UnlockHeight() uint64
+	LockTime() uint64
 }

--- a/transactions/staketx.go
+++ b/transactions/staketx.go
@@ -79,7 +79,7 @@ func (s *Stake) Equals(t Transaction) bool {
 	return true
 }
 
-func (s *Stake) UnlockHeight() uint64 {
+func (s *Stake) LockTime() uint64 {
 	return s.Lock
 }
 

--- a/transactions/standardtx.go
+++ b/transactions/standardtx.go
@@ -172,7 +172,7 @@ func (s *Standard) ProveRangeProof() error {
 	return nil
 }
 
-func (s *Standard) UnlockHeight() uint64 {
+func (s *Standard) LockTime() uint64 {
 	return 0
 }
 

--- a/transactions/timelock.go
+++ b/transactions/timelock.go
@@ -76,7 +76,7 @@ func (tl *Timelock) Equals(t Transaction) bool {
 	return true
 }
 
-func (tl *Timelock) UnlockHeight() uint64 {
+func (tl *Timelock) LockTime() uint64 {
 	return tl.Lock
 }
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -97,18 +97,19 @@ func TestCheckBlock(t *testing.T) {
 
 	var numTxs = 3 // numTxs to send to Bob
 
-	var blk block.Block
+	blk := block.NewBlock()
+	blk.Header.Height = 0
 	for i := 0; i < numTxs; i++ {
 		tx := generateStandardTx(t, *bobAddr, 20, alice)
 		assert.Nil(t, err)
 		blk.AddTx(tx)
 	}
 
-	count, err := bob.CheckWireBlockReceived(blk)
+	count, err := bob.CheckWireBlockReceived(*blk)
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(numTxs), count)
 
-	_, err = alice.CheckWireBlockSpent(blk)
+	_, err = alice.CheckWireBlockSpent(*blk)
 	assert.Nil(t, err)
 }
 
@@ -117,11 +118,12 @@ func TestSpendLockedInputs(t *testing.T) {
 	alice := generateWallet(t, netPrefix, "alice", walletPath)
 	defer os.Remove(walletPath)
 
-	var blk block.Block
+	blk := block.NewBlock()
+	blk.Header.Height = 0
 	tx := generateStakeTx(t, 20, alice, 100000)
 	blk.AddTx(tx)
 
-	_, err := alice.CheckWireBlockReceived(blk)
+	_, err := alice.CheckWireBlockReceived(*blk)
 	assert.Nil(t, err)
 
 	// Attempt to send a Standard tx with this single input we received.


### PR DESCRIPTION
Fixes #18, and names `UnlockHeight` to `LockTime` as it is more descriptive of what the fields means.