### PR TITLE
write and fetch keyimages with a separate prefix

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -24,6 +24,7 @@ var (
 	inputPrefix        = []byte{0x00}
 	walletHeightPrefix = []byte{0x01}
 	txRecordPrefix     = []byte{0x02}
+	keyImagePrefix     = []byte{0x03}
 
 	writeOptions = &opt.WriteOptions{NoWriteMerge: false, Sync: true}
 )
@@ -65,11 +66,12 @@ func (db *DB) PutInput(encryptionKey []byte, pubkey ristretto.Point, amount, mas
 }
 
 func (db *DB) RemoveInput(pubkey []byte, keyImage []byte) error {
-	key := append(inputPrefix, pubkey...)
+	inputKey := append(inputPrefix, pubkey...)
+	keyImageKey := append(keyImagePrefix, keyImage...)
 
 	b := new(leveldb.Batch)
-	b.Delete(key)
-	b.Delete(keyImage)
+	b.Delete(inputKey)
+	b.Delete(keyImageKey)
 
 	return db.storage.Write(b, writeOptions)
 }
@@ -296,4 +298,14 @@ func (db *DB) PutTxRecord(tx transactions.Transaction, direction txrecords.Direc
 
 	value := make([]byte, 1)
 	return db.Put(key, value)
+}
+
+func (db *DB) PutKeyImage(keyImage []byte, pubKey []byte) error {
+	key := append(keyImagePrefix, keyImage...)
+	return db.Put(key, pubKey)
+}
+
+func (db *DB) GetPubKey(keyImage []byte) ([]byte, error) {
+	key := append(keyImagePrefix, keyImage...)
+	return db.Get(key)
 }

--- a/database/database.go
+++ b/database/database.go
@@ -300,9 +300,9 @@ func (db *DB) PutTxRecord(tx transactions.Transaction, direction txrecords.Direc
 	return db.Put(key, value)
 }
 
-func (db *DB) PutKeyImage(keyImage []byte, pubKey []byte) error {
+func (db *DB) PutKeyImage(keyImage []byte, outputKey []byte) error {
 	key := append(keyImagePrefix, keyImage...)
-	return db.Put(key, pubKey)
+	return db.Put(key, outputKey)
 }
 
 func (db *DB) GetPubKey(keyImage []byte) ([]byte, error) {

--- a/wallet/transactions.go
+++ b/wallet/transactions.go
@@ -104,7 +104,7 @@ func (w *Wallet) Sign(tx SignableTx) error {
 	// Remove inputs from the db, to prevent accidental double-spend attempts
 	// when sending transactions quickly after one another.
 	for _, input := range tx.StandardTx().Inputs {
-		pubKey, err := w.db.Get(input.KeyImage.Bytes())
+		pubKey, err := w.db.GetPubKey(input.KeyImage.Bytes())
 		if err == leveldb.ErrNotFound {
 			continue
 		}

--- a/wallet/transactions.go
+++ b/wallet/transactions.go
@@ -104,7 +104,7 @@ func (w *Wallet) Sign(tx SignableTx) error {
 	// Remove inputs from the db, to prevent accidental double-spend attempts
 	// when sending transactions quickly after one another.
 	for _, input := range tx.StandardTx().Inputs {
-		pubKey, err := w.db.GetPubKey(input.KeyImage.Bytes())
+		outputKey, err := w.db.GetPubKey(input.KeyImage.Bytes())
 		if err == leveldb.ErrNotFound {
 			continue
 		}
@@ -112,7 +112,7 @@ func (w *Wallet) Sign(tx SignableTx) error {
 			return err
 		}
 
-		w.db.RemoveInput(pubKey, input.KeyImage.Bytes())
+		w.db.RemoveInput(outputKey, input.KeyImage.Bytes())
 	}
 
 	return nil

--- a/wallet/txinchecker.go
+++ b/wallet/txinchecker.go
@@ -59,7 +59,7 @@ func (w *Wallet) CheckWireBlockSpent(blk block.Block) (uint64, error) {
 func (w *Wallet) removeSpentOutputs(txChecker TxInChecker) (uint64, error) {
 	var didSpendFunds uint64
 	for _, keyImage := range txChecker.keyImages {
-		pubKey, err := w.db.GetPubKey(keyImage)
+		outputKey, err := w.db.GetPubKey(keyImage)
 		if err == leveldb.ErrNotFound {
 			continue
 		}
@@ -69,7 +69,7 @@ func (w *Wallet) removeSpentOutputs(txChecker TxInChecker) (uint64, error) {
 
 		didSpendFunds++
 
-		if err := w.db.RemoveInput(pubKey, keyImage); err != nil {
+		if err := w.db.RemoveInput(outputKey, keyImage); err != nil {
 			return didSpendFunds, err
 		}
 	}

--- a/wallet/txinchecker.go
+++ b/wallet/txinchecker.go
@@ -59,7 +59,7 @@ func (w *Wallet) CheckWireBlockSpent(blk block.Block) (uint64, error) {
 func (w *Wallet) removeSpentOutputs(txChecker TxInChecker) (uint64, error) {
 	var didSpendFunds uint64
 	for _, keyImage := range txChecker.keyImages {
-		pubKey, err := w.db.Get(keyImage)
+		pubKey, err := w.db.GetPubKey(keyImage)
 		if err == leveldb.ErrNotFound {
 			continue
 		}

--- a/wallet/txoutchecker.go
+++ b/wallet/txoutchecker.go
@@ -76,5 +76,5 @@ func (w *Wallet) writeKeyImageToDatabase(output transactions.Output, privKey ris
 	var pubKey ristretto.Point
 	pubKey.ScalarMultBase(&privKey)
 	keyImage := mlsag.CalculateKeyImage(privKey, pubKey)
-	return w.db.Put(keyImage.Bytes(), output.PubKey.P.Bytes())
+	return w.db.PutKeyImage(keyImage.Bytes(), output.PubKey.P.Bytes())
 }


### PR DESCRIPTION
this prevents the keyimages from being iterated on if they share the same first byte as any of the other prefixes, causing decoding errors

fixes #34 