### PR TITLE
Re-formulate error message for height mismatch

### DIFF
--- a/v2/wallet/wallet.go
+++ b/v2/wallet/wallet.go
@@ -141,7 +141,7 @@ func (w *Wallet) CheckWireBlock(blk block.Block) (uint64, uint64, error) {
 	}
 
 	if blk.Header.Height != walletHeight {
-		return 0, 0, errors.New("last seen block does not precede provided block")
+		return 0, 0, fmt.Errorf("mismatch between block height and wallet height\nblock height: %v - wallet height: %v\n", blk.Header.Height, walletHeight)
 	}
 
 	spentCount, err := w.CheckWireBlockSpent(blk)


### PR DESCRIPTION
This aims to avoid confusion, as the error message
does not make immediately clear that it concerns
the wallet.

Fixes #50 